### PR TITLE
Adding 'registerTask' section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,20 @@ module.exports.tasks = {
 
 This makes it easier when in the future you'd like to move the `watch:gruntfile` task configuration to another file for instance.
 
+
+### Using load-grunt-configs for custom tasks
+
+if you want to register a custom task and use `load-grunt-config` to load it automatically you just need to return your registered task as a configuration:
+
+```jaavascript
+//config/task.runAllTheThings.js
+module.exports = {
+    return grunt.registerTask('runAllTheThings', 'this task runs all the things', function(){
+        grunt.task.run(['jshint', 'clean', 'uglify']);
+    });
+}
+```
+
 ### Troubleshooting
 
 The tradeoff of a neatly organized Grunt configuration is sometimes having trouble locating which file is declaring exactly what.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This makes it easier when in the future you'd like to move the `watch:gruntfile`
 
 if you want to register a custom task and use `load-grunt-config` to load it automatically you just need to return your registered task as a configuration:
 
-```jaavascript
+```javascript
 //config/task.runAllTheThings.js
 module.exports = {
     return grunt.registerTask('runAllTheThings', 'this task runs all the things', function(){


### PR DESCRIPTION
I ran into this issue with very little information coming back from the task runner `Warning: No valid task configuration found in config/task.*.js Use --force to continue` 

I figured it may be nice to call out that this is possible through the task
